### PR TITLE
Use relative path instead of __dirname

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = require(__dirname + '/src/index');
+module.exports = require('./src/index');


### PR DESCRIPTION
This is useful for packaging tools which parse `require()` calls, like "pkg" module.